### PR TITLE
Option to export either png or pse

### DIFF
--- a/configuration/config.json
+++ b/configuration/config.json
@@ -5,5 +5,6 @@
         "seq_lineage": "H3",
         "numbering_scheme": "H3",
         "output_dir": "figures",
-        "reference_mode": false
+        "reference_mode": false,
+        "export_files": ["PSE", "PNG"]
 }

--- a/src/make_comparison_figure.py
+++ b/src/make_comparison_figure.py
@@ -15,13 +15,19 @@ base_filename = make_figure(comparison)
 
 # Save figures
 cmd.set("opaque_background", "on")
-cmd.png('%s/%s.png'%(
-        figure_dir,
-        base_filename),
-    width=800,
-    height=800,
-    ray=1,
-    dpi=300)
-cmd.save('%s/%s.pse'%(
-        figure_dir,
-        base_filename))
+
+exports = parameters["export_files"]
+
+if "PNG" in (e.upper() for e in exports):
+    cmd.png('%s/%s.png'%(
+            figure_dir,
+            base_filename),
+        width=800,
+        height=800,
+        ray=1,
+        dpi=300)
+
+if "PSE" in (e.upper() for e in exports):
+    cmd.save('%s/%s.pse'%(
+            figure_dir,
+            base_filename))


### PR DESCRIPTION
PNG export is the most resource intensive part of generating static figures so I've made the exports optional.

Changes:

* Option for exporting PNG, PSE, or both.