### PR TITLE
File comparison script

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,3 +186,11 @@ pytest
 * 2017-2019 cell-based recommendation (name = `A/Michigan/45/2015`, id = `EPI699812`
 * 2009-2017 cell-based recommendation (name = `A/California/04/2009`, id = `EPI178457`)
 * 2013-2014 example from Linderman et al. (name = `A/Colorado/3514/2013`, id = `EPI501723`)
+
+
+## Scripts
+
+* `renumber_H1.py` and `renumber_H3.py`: _Re-index PDB files for use with Flu Strain Compare._
+* `print_pymol_objects.py`: _Print chains and selections in a .pse file to compare modifications to the model._
+
+

--- a/src/print_pymol_objects.py
+++ b/src/print_pymol_objects.py
@@ -1,0 +1,42 @@
+from pymol import cmd
+import os
+import sys
+
+input_file_base = ""
+
+# Parse parameters, open input file, derive output directory name.
+try:
+    input_param = sys.argv[1]
+    print(f"Opening {input_param}...")
+    cmd.load(input_param)
+    input_file_base = os.path.split(input_param)[-1].split(".")[0]
+except:
+    print(f"Provide input .pse file path: python <path>/<filename>.pse.")
+    exit()
+
+# Create output directory based on input file name.
+os.mkdir(input_file_base)
+
+# Iterate over objects in file and print the type and properties of the atoms to files named for the PyMOL chain. Note: Does not include coordinates and a few other properties. Objects are generally instances of chempy classes.
+# Chains are pymol models: https://fossies.org/dox/pymol-open-source-2.5.0/models_8py_source.html
+for x in cmd.get_names("objects"):
+    for ch in cmd.get_chains(x):
+        m = cmd.get_model(f"chain {ch}")
+        print(f"Saving objects in chain {ch}...")
+        filename = os.path.join(input_file_base, f"chain_{ch}.txt")
+        with open(filename, "a") as f:
+            print(type(m), file=f)
+            for at in m.atom:
+                print(f"{at.resn} {at.resi} {at.name}", file=f)
+
+# Iterate over selections and print to "selections.txt" file.
+print("Saving selections...")
+filename = os.path.join(input_file_base, f"selections.txt")
+with open(filename, "a") as f:
+    for x in cmd.get_names("selections"):
+        m = cmd.get_model(x)
+        print(x, file=f)
+        print(type(m), file=f)
+        for a in m.atom:
+            print(f"{at.resn} {at.resi} {at.name}", file=f)
+


### PR DESCRIPTION
Script to help compare PyMOL files and a README entry on FSC scripts.

Usage: `python src/print_pymol_objects.py data/H1_pngs.pse`. Will create a `H1_pngs` directory, a text file for each chain and a file for the selections in the pse file.
